### PR TITLE
Remove Audio.FreeSoundEffect call that causes a crash

### DIFF
--- a/src/src/GameResources.cs
+++ b/src/src/GameResources.cs
@@ -226,7 +226,6 @@ namespace Battleships
             SwinGame.FreeBitmap(_Animation);
             SwinGame.FreeBitmap(_LoaderEmpty);
             SwinGame.FreeBitmap(_LoaderFull);
-            Audio.FreeSoundEffect(_StartSound);
             SwinGame.ChangeScreenSize(width, height);
         }
 


### PR DESCRIPTION
See card: https://trello.com/c/57fJDaeb/20-bug-game-crashes-after-launch